### PR TITLE
Add support for OSX

### DIFF
--- a/vagrant
+++ b/vagrant
@@ -50,7 +50,7 @@ _vagrant()
     then
         case "$prev" in
             "init")
-              local box_list=$(find $HOME/.vagrant.d/boxes/* -maxdepth 0 -type d -printf '%f ')
+              local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
               COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
               return 0
             ;;
@@ -82,7 +82,7 @@ _vagrant()
       then
         case "$prev" in
             "remove"|"repackage")
-              local box_list=$(find $HOME/.vagrant.d/boxes/* -maxdepth 0 -type d -printf '%f ')
+              local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
               COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
               return 0
               ;;


### PR DESCRIPTION
Tweaked the `find` command used to locate boxes so that it works with
both Debian and OSX variants of `find`. Tested on Debian squeeze and OSX
Lion.
