### PR TITLE
Add 'vagrant ssh' completion.

### DIFF
--- a/vagrant
+++ b/vagrant
@@ -1,4 +1,39 @@
 #!/bin/bash
+pwdln() {
+
+   # Doing PE from the beginning of the string is needed
+   # so we get a string of 0 len to break the until loop.
+
+   pwdmod="${PWD}/"
+   itr=0
+   until [[ -z "$pwdmod" ]];do
+      itr=$(($itr+1))
+      pwdmod="${pwdmod#*/}"
+   done
+   echo -n $(($itr-1))
+
+}
+
+vagrantinvestigate() {
+
+   if [[ -f "${PWD}/.vagrant" ]];then
+      echo "${PWD}/.vagrant"
+      return 0
+   else
+      pwdmod2="${PWD}"                                     #  Since we didn't find a $PWD/.vagrant, we're going to pop
+      for (( i=2; i<=$(pwdln); i++ ));do                   #  a directory off the end of the $pwdmod2 stack until we
+         pwdmod2="${pwdmod2%/*}"                           #  come across a ./.vagrant. /home/igneous/proj/1 will start at
+         if [[ -f "${pwdmod2}/.vagrant" ]];then                #  /home/igneous/proj because of our loop starting at 2.
+            echo "${pwdmod2}/.vagrant"
+            return 0
+         fi
+      done
+   fi
+
+   return 1
+
+}
+
 _vagrant()
 {
     cur="${COMP_WORDS[COMP_CWORD]}"
@@ -17,6 +52,13 @@ _vagrant()
             "init")
               local box_list=$(find $HOME/.vagrant.d/boxes/* -maxdepth 0 -type d -printf '%f ')
               COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
+              return 0
+            ;;
+            "ssh")
+              vagrant_state_file=$(vagrantinvestigate) || return 1
+              #Got lazy here.. I'd like to eventually replace this with a pure bash solution.
+              running_vm_list=$(grep 'active' $vagrant_state_file | sed -e 's/"active"://;s/,/\n/' | cut -d '"' -f 2 | tr '\n' ' ')
+              COMPREPLY=($(compgen -W "${running_vm_list}" -- ${cur}))
               return 0
             ;;
             "box")


### PR DESCRIPTION
Search backwards through our pwd until we find .vagrant, and list the active VMs when 'vagrant ssh' is tab-completed.
