### PR TITLE
not working on OS X 10.6.8, vagrant 1.2.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,25 @@ Debian/Ubuntu
 * cp vagrant /etc/bash_completion.d/vagrant
 * . ~/bashrc
 
+OS X
+----
+
+With `homebrew <http://brew.sh/>`_ you can install the
+`vagrant-completion` recipe to use this plugin
+
+.. code:: bash
+
+    brew tap homebrew/completions
+    brew install vagrant-completion
+
+then add the following lines to your ~/.bashrc
+
+.. code:: bash
+
+    if [ -f `brew --prefix`/etc/bash_completion.d/vagrant ]; then
+	source `brew --prefix`/etc/bash_completion.d/vagrant
+    else
+
 
 License
 =======


### PR DESCRIPTION
I copied the vagrant file into /etc/bash_completion.d/vagrant and re-sourced [my ~/.bashrc](https://github.com/deanmalmgren/config/blob/master/bashrc) but the tab completion doesn't seem to be working for me. Is this a problem with my .bashrc, an issue with OS X, or something else altogether?

Happy to help debug but I don't really know where to start. I'd love to use this package as our vagrant VM names are getting a little annoying to have to type all the time...
