### PR TITLE
.vagrant directory holds state?

### DIFF
--- a/vagrant
+++ b/vagrant
@@ -20,10 +20,14 @@ __vagrantinvestigate() {
       echo "${PWD}/.vagrant"
       return 0
    else
-      pwdmod2="${PWD}"                                     #  Since we didn't find a $PWD/.vagrant, we're going to pop
-      for (( i=2; i<=$(__pwdln); i++ ));do                   #  a directory off the end of the $pwdmod2 stack until we
-         pwdmod2="${pwdmod2%/*}"                           #  come across a ./.vagrant. /home/igneous/proj/1 will start at
-         if [ -f "${pwdmod2}/.vagrant" -o -d "${pwdmod2}.vagrant" ];then                #  /home/igneous/proj because of our loop starting at 2.
+      #  Since we didn't find a $PWD/.vagrant, we're going to pop
+      #  pwdmod2="${PWD}" a directory off the end of the $pwdmod2
+      #  stack until we come across a ./.vagrant. /home/igneous/proj/1
+      #  will start at /home/igneous/proj because of our loop starting
+      #  at 2.
+      for (( i=2; i<=$(__pwdln); i++ ));do
+         pwdmod2="${pwdmod2%/*}"
+         if [ -f "${pwdmod2}/.vagrant" -o -d "${pwdmod2}.vagrant" ];then
             echo "${pwdmod2}/.vagrant"
             return 0
          fi


### PR DESCRIPTION
I'm running vagrant 1.2.2 on OS X 10.6.8. I'm not sure if this is an OS-specific difference or whether vagrant started storing its state differently, but I do not have a `.vagrant` file --- I have a `.vagrant/` directory --- that stores the state of the currently running (and previously launched) vagrant boxes in a format that looks like this:

```
# tree .vagrant
.vagrant
└── machines
    ├── vm-numero-uno
    │   └── rackspace
    │       └── id
    ├── vm-numero-dos
    │   └── virtualbox
    └── vm-numero-tres
        └── virtualbox
            └── id
```

In this case, virtual machines `vm-numero-uno` and vm-numero-tres`are running because they have the`id`file. Virtual machine`vm-numero-dos` is not currently running but has been run before. The present solution works on my system to identify all of these machines.

The tricky bit is that this directory structure is launched _the first time_ a machine is `vagrant up`-ed. So if you add a new virtual machine called `vm-numero-tres`, it isn't possible to tab complete on the name. How does the present solution work with the `.vagrant` file? Are unlaunched virtual machines stored in the .vagrant file somehow or is this problem present there too?

If its a common issue, we could probably do something smart with `vagrant status`, but I'd definitely prefer not to because it is s------l-------o--------w.
