### PR TITLE
Correct .bash_rc code in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ then add the following lines to your ~/.bashrc
 
     if [ -f `brew --prefix`/etc/bash_completion.d/vagrant ]; then
 	source `brew --prefix`/etc/bash_completion.d/vagrant
-    else
+    fi
 
 
 License


### PR DESCRIPTION
Current .bash_rc code in the README isn't valid. This should fix that.
