### PR TITLE
unable to tab complete machine names in subdirectories

### DIFF
--- a/vagrant
+++ b/vagrant
@@ -28,7 +28,7 @@ __vagrantinvestigate() {
       pwdmod2="${PWD}"
       for (( i=2; i<=$(__pwdln); i++ ));do
          pwdmod2="${pwdmod2%/*}"
-         if [ -f "${pwdmod2}/.vagrant" -o -d "${pwdmod2}.vagrant" ];then
+         if [ -f "${pwdmod2}/.vagrant" -o -d "${pwdmod2}/.vagrant" ];then
             echo "${pwdmod2}/.vagrant"
             return 0
          fi


### PR DESCRIPTION
This is totally my fault; I should have double checked this before issuing the pull request for #8. I'm unable to tab complete for matching machine names in subdirectories. I can probably fix this myself, but I don't know what `pwdmod2="${pwdmod2%/*}"` is doing. 

This functionality apparently doesn't work in OS X. I added a [debugging branch](https://github.com/deanmalmgren/vagrant-bash-completion/tree/investigate-__vagrantinvestigate) with some [debugging statements in the __vagrantinvestigate function](https://github.com/deanmalmgren/vagrant-bash-completion/blob/3f74283fce3ad37fae93fb3cb1aa50d5307ab8fe/vagrant). This is what the output is in OS X:

``` bash
[hal-9000 subdir/of/vagrant/box]$ __vagrantinvestigate 
recursion depth: 5
who are you pwdmod2? ''
who are you pwdmod2? ''
who are you pwdmod2? ''
who are you pwdmod2? ''
```
