### PR TITLE
vagrant bash completion doesn't ignore plugin commands anymore

### DIFF
--- a/vagrant
+++ b/vagrant
@@ -67,7 +67,7 @@ _vagrant()
 {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    commands="box destroy halt help init package plugin provision reload resume ssh ssh-config status suspend up"
+    commands=`vagrant help | sed -e '1,/Available subcommands/ s/.*//' -e '/For help/,$ s/.*//' | tr -ds '\n' '[:blank:]'`
 
     if [ $COMP_CWORD == 1 ]
     then


### PR DESCRIPTION
When a plugin adds subcommands to vagrant, these would be ignored by vagrants bash completion. This commit fixes the problem.
### Caution

I have to admit this change slows vagrant bash completion down quite a bit and I have no real idea how to fix this problem. I'm not a bash hacker, though I try to learn.
If vagrant would have a simple command or switch to print out all available commands this would be better, but currently vagrant doesn't even print consistent line indentation for all commands when running `$ vagrant help`. (Some seem to start with spaces, some with tabs.)
