### PR TITLE
Change acquired the subcommand from vagrant-help.

### DIFF
--- a/vagrant
+++ b/vagrant
@@ -67,7 +67,7 @@ _vagrant()
 {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    commands="box destroy halt help init package plugin provision reload resume ssh ssh-config status suspend up"
+    commands=$(vagrant help | tr -s ' ' | sed -e '1,/Available subcommands/ d' -e '/For help/,$ d' -e '/^\s*$/ d' | cut -f1,2 -d' ' | tr -ds '\n' '[:blank:]')
 
     if [ $COMP_CWORD == 1 ]
     then
@@ -132,4 +132,3 @@ _vagrant()
 
 }
 complete -F _vagrant vagrant
-


### PR DESCRIPTION
I installd the subcommand-plugin like vagrant-global-stuaus. 
I thought that I would like to complement the subcommand.
plz check this pullrequest.

$ vagrant plugin list
vagrant-global-status (0.1.4)
vagrant-lxc (0.7.0)

$ vagrant[TAB]...
box            global-status  help           package        provision      resume         ssh-config     suspend
destroy        halt           init           plugin         reload         ssh            status         up

thanks,
hiono
