### PR TITLE
Cleanup and improvements

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 (The MIT License)
 
 Copyright (c) 2014 Kura
+Copyright (c) 2015 Six <brbsix@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the 'Software'), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: install uninstall deb
 
 install:
-	cp etc/bash_completion.d/vagrant /etc/bash_completion.d/vagrant
+	install -m 0644 etc/bash_completion.d/vagrant /etc/bash_completion.d/vagrant
 
 uninstall:
 	rm /etc/bash_completion.d/vagrant

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,8 @@ Debian/Ubuntu
 
 .. code:: bash
 
-    sudo wget https://raw.github.com/kura/vagrant-bash-completion/master/etc/bash_completion.d/vagrant -O /etc/bash_completion.d/vagrant
+    wget -q https://raw.github.com/brbsix/vagrant-bash-completion/master/etc/bash_completion.d/vagrant
+    sudo install -m 0644 vagrant /etc/bash_completion.d/vagrant-test
 
 
 OS X

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,3 @@
-Getting stuff merged
-====================
-
-If you have a pull request you want merged, shout at me
-on Twitter [at]kuramanga or via email kura[at]kura[dot]io
-
-
 Installation
 ============
 
@@ -17,44 +10,16 @@ Debian/Ubuntu
     sudo install -m 0644 vagrant /etc/bash_completion.d/vagrant-test
 
 
-OS X
-----
-
-@kura is now supporting releases to homebrew-completions because
-other people stopped doing it.
-
-*Please note: @kura is not a Mac user, all Mac & Homebrew support
-was provided by additional contributors. I will help as much as I
-can but I can't promise anything. Sorry.*
-
-With `homebrew <http://brew.sh/>`_ you can install the
-`vagrant-completion` recipe to use this plugin
-
-.. code:: bash
-
-    brew tap homebrew/completions
-    brew install vagrant-completion
-
-then add the following lines to your ~/.bashrc
-
-.. code:: bash
-
-    if [ -f `brew --prefix`/etc/bash_completion.d/vagrant ]; then
-	source `brew --prefix`/etc/bash_completion.d/vagrant
-    fi
-
-
 License
 =======
 
 This software is licensed using the MIT License.
 The license is provided in the `source code repository
-<https://github.com/kura/vagrant-bash-completion/blob/master/LICENSE>`_.
+<https://github.com/brbsix/vagrant-bash-completion/blob/master/LICENSE>`_.
 
 
-Notes
-=====
+Prior Contributors
+===================
 
-Original - https://github.com/nfedyashev/bash-it/blob/master/plugins/vagrant.plugins.bash
-
-Mine has more functionality and changes to locations
+https://github.com/nfedyashev/bash-it/blob/master/plugins/vagrant.plugins.bash
+https://github.com/kura/vagrant-bash-completion/blob/master/etc/bash_completion.d/vagrant

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -138,13 +138,11 @@ _vagrant() {
         case "$action" in
 
             box)
-                case "$prev" in
-                    remove|repackage)
-                        local box_list=$(__vagrantboxes)
-                        COMPREPLY=($(compgen -W "$box_list" -- "$cur"))
-                        return 0
-                        ;;
-                esac
+                if [[ $prev =~ ^(remove|repackage)$ ]]; then
+                    local box_list=$(__vagrantboxes)
+                    COMPREPLY=($(compgen -W "$box_list" -- "$cur"))
+                    return 0
+                fi
                 ;;
 
             snapshot)

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -46,7 +46,7 @@ _vagrant() {
 
     cur=${COMP_WORDS[COMP_CWORD]}
     prev=${COMP_WORDS[COMP_CWORD-1]}
-    commands='snapshot box connect destroy docker-logs docker-run global-status halt help init list-commands login package plugin provision rdp reload resume rsync rsync-auto share ssh ssh-config status suspend up version'
+    commands=$(vagrant list-commands 2>/dev/null | tail -n+4 | awk '{print $1}' | sort)
 
     if (( COMP_CWORD == 1 )); then
 

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -93,7 +93,7 @@ _vagrant() {
                 ;;
 
             destroy)
-                environments=$(vagrant global-status 2>/dev/null | awk '/^-{80}$/ {getline; while (NF != 0) {ids[$1]++; getline}} END {if (length(ids)) for (id in ids) print id; else exit(1)}') || return 1
+                environments=$(vagrant global-status 2>/dev/null | awk '/^-{80}$/ { getline; while (NF != 0) { print$1; getline } }')
                 COMPREPLY=($(compgen -W "$environments" -- "$cur"))
                 return 0
                 ;;

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -24,34 +24,34 @@
 
 
 __pwdln() {
-    pwdmod="${PWD}/"
+    pwdmod=$PWD/
     itr=0
 
-    until [[ -z "$pwdmod" ]]; do
-        itr=$(($itr+1))
-        pwdmod="${pwdmod#*/}"
+    until [[ -z $pwdmod ]]; do
+        itr=$(( itr + 1 ))
+        pwdmod=${pwdmod#*/}
     done
 
-    echo -n $(($itr-1))
+    echo -n $(( itr - 1 ))
 }
 
 __vagrantinvestigate() {
-    if [ -n "$VAGRANT_CWD" ]; then
-        if [ -f "${VAGRANT_CWD}/.vagrant" -o -d "${VAGRANT_CWD}/.vagrant" ]; then
-        echo "${VAGRANT_CWD}/.vagrant"
+    if [[ -n $VAGRANT_CWD ]]; then
+        if [[ -f $VAGRANT_CWD/.vagrant || -d $VAGRANT_CWD/.vagrant ]]; then
+        echo "$VAGRANT_CWD/.vagrant"
         return 0
         fi
     fi
 
-    if [ -f "${PWD}/.vagrant" -o -d "${PWD}/.vagrant" ]; then
-        echo "${PWD}/.vagrant"
+    if [[ -f $PWD/.vagrant || -d $PWD/.vagrant ]]; then
+        echo "$PWD/.vagrant"
         return 0
     else
-        pwdmod2="${PWD}"
+        pwdmod2=$PWD
         for (( i=2; i<=$(__pwdln); i++ )); do
-            pwdmod2="${pwdmod2%/*}"
-            if [ -f "${pwdmod2}/.vagrant" -o -d "${pwdmod2}/.vagrant" ]; then
-                echo "${pwdmod2}/.vagrant"
+            pwdmod2=${pwdmod2%/*}
+            if [[ -f $pwdmod2/.vagrant || -d $pwdmod2/.vagrant ]]; then
+                echo "$pwdmod2/.vagrant"
                 return 0
             fi
         done
@@ -62,13 +62,13 @@ __vagrantinvestigate() {
 
 _vagrant() {
 
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev=${COMP_WORDS[COMP_CWORD-1]}
     commands='snapshot box connect destroy docker-logs docker-run global-status halt help init list-commands login package plugin provision rdp reload resume rsync rsync-auto share ssh ssh-config status suspend up version'
 
     if (( COMP_CWORD == 1 )); then
 
-        COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
+        COMPREPLY=($(compgen -W "$commands" -- "$cur"))
         return 0
 
     elif (( COMP_CWORD == 2 )); then
@@ -77,51 +77,51 @@ _vagrant() {
 
             box)
                 box_commands='add help list remove repackage'
-                COMPREPLY=($(compgen -W "${box_commands}" -- ${cur}))
+                COMPREPLY=($(compgen -W "$box_commands" -- "$cur"))
                 return 0
                 ;;
 
             halt|provision|reload|resume|ssh|ssh-config|suspend)
                 vagrant_state_file=$(__vagrantinvestigate) || return 1
                 if [[ -f $vagrant_state_file ]]; then
-                    running_vm_list=$(grep 'active' $vagrant_state_file | sed -e 's/"active"://' | tr ',' '\n' | cut -d '"' -f 2 | tr '\n' ' ')
+                    running_vm_list=$(grep active "$vagrant_state_file" | sed -e 's/"active"://' | tr ',' '\n' | cut -d '"' -f 2 | tr '\n' ' ')
                 else
-                    running_vm_list=$(find $vagrant_state_file -type f -name "id" | awk -F"/" '{print $(NF-2)}')
+                    running_vm_list=$(find "$vagrant_state_file" -type f -name id | awk -F/ '{print $(NF-2)}')
                 fi
-                COMPREPLY=($(compgen -W "${running_vm_list}" -- ${cur}))
+                COMPREPLY=($(compgen -W "$running_vm_list" -- "$cur"))
                 return 0
                 ;;
 
             help)
-                COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
+                COMPREPLY=($(compgen -W "$commands" -- "$cur"))
                 return 0
                 ;;
 
             init)
-                local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
-                COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
+                local box_list=$(find "$HOME/.vagrant.d/boxes" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
+                COMPREPLY=($(compgen -W "$box_list" -- "$cur"))
                 return 0
                 ;;
 
             plugin)
                 plugin_commands='install license list uninstall update'
-                COMPREPLY=($(compgen -W "${plugin_commands}" -- ${cur}))
+                COMPREPLY=($(compgen -W "$plugin_commands" -- "$cur"))
                 return 0
                 ;;
 
             snapshot)
                 snapshot_commands='back delete go list take'
-                COMPREPLY=($(compgen -W "${snapshot_commands}" -- ${cur}))
+                COMPREPLY=($(compgen -W "$snapshot_commands" -- "$cur"))
                 return 0
                 ;;
 
             up)
                 vagrant_state_file=$(__vagrantinvestigate) || return 1
                 if [[ -d $vagrant_state_file ]]; then
-                    vm_list=$(find $vagrant_state_file/machines -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+                    vm_list=$(find "$vagrant_state_file/machines" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
                 fi
                 local up_commands='--no-provision'
-                COMPREPLY=($(compgen -W "${up_commands} ${vm_list}" -- ${cur}))
+                COMPREPLY=($(compgen -W "$up_commands $vm_list" -- "$cur"))
                 return 0
                 ;;
 
@@ -129,31 +129,31 @@ _vagrant() {
 
     elif (( COMP_CWORD == 3 )); then
 
-        action="${COMP_WORDS[COMP_CWORD-2]}"
+        action=${COMP_WORDS[COMP_CWORD-2]}
 
         case "$action" in
 
             box)
                 case "$prev" in
                     remove|repackage)
-                        local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
-                        COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
+                        local box_list=$(find "$HOME/.vagrant.d/boxes" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
+                        COMPREPLY=($(compgen -W "$box_list" -- "$cur"))
                         return 0
                         ;;
                 esac
                 ;;
 
             snapshot)
-                if [ "$prev" == "go" ]; then
+                if [[ $prev = go ]]; then
                     local snapshot_list=$(vagrant snapshot list | awk '/Name:/ { print $2 }')
-                    COMPREPLY=($(compgen -W "${snapshot_list}" -- ${cur}))
+                    COMPREPLY=($(compgen -W "$snapshot_list" -- "$cur"))
                     return 0
                 fi
                 ;;
 
             up)
-                if [ "$prev" == "--no-provision" ]; then
-                    COMPREPLY=($(compgen -W "${vm_list}" -- ${cur}))
+                if [[ $prev = --no-provision ]]; then
+                    COMPREPLY=($(compgen -W "$vm_list" -- "$cur"))
                     return 0
                 fi
                 ;;

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -59,7 +59,7 @@ __vagrantinvestigate() {
 _vagrant() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    commands="snapshot box connect destroy docker-logs docker-run global-status halt help init list-commands login package plugin provision rdp reload resume rsync rsync-auto share ssh ssh-config status suspend up version"
+    commands='snapshot box connect destroy docker-logs docker-run global-status halt help init list-commands login package plugin provision rdp reload resume rsync rsync-auto share ssh ssh-config status suspend up version'
 
     if [ $COMP_CWORD == 1 ]
     then
@@ -70,22 +70,22 @@ _vagrant() {
     if [ $COMP_CWORD == 2 ]
     then
         case "$prev" in
-            "init")
+            init)
                 local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
                 COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
                 return 0
                 ;;
-            "up")
+            up)
                 vagrant_state_file=$(__vagrantinvestigate) || return 1
                 if [[ -d $vagrant_state_file ]]
                 then
                     vm_list=$(find $vagrant_state_file/machines -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
                 fi
-                local up_commands="--no-provision"
+                local up_commands='--no-provision'
                 COMPREPLY=($(compgen -W "${up_commands} ${vm_list}" -- ${cur}))
                 return 0
                 ;;
-            "ssh"|"provision"|"reload"|"halt"|"suspend"|"resume"|"ssh-config")
+            ssh|provision|reload|halt|suspend|resume|ssh-config)
                 vagrant_state_file=$(__vagrantinvestigate) || return 1
                 if [[ -f $vagrant_state_file ]]
                 then
@@ -96,22 +96,22 @@ _vagrant() {
                 COMPREPLY=($(compgen -W "${running_vm_list}" -- ${cur}))
                 return 0
                 ;;
-            "box")
-                box_commands="add help list remove repackage"
+            box)
+                box_commands='add help list remove repackage'
                 COMPREPLY=($(compgen -W "${box_commands}" -- ${cur}))
                 return 0
                 ;;
-            "plugin")
-                plugin_commands="install license list uninstall update"
+            plugin)
+                plugin_commands='install license list uninstall update'
                 COMPREPLY=($(compgen -W "${plugin_commands}" -- ${cur}))
                 return 0
                 ;;
-            "help")
+            help)
                 COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
                 return 0
                 ;;
-            "snapshot")
-                snapshot_commands="back delete go list take"
+            snapshot)
+                snapshot_commands='back delete go list take'
                 COMPREPLY=($(compgen -W "${snapshot_commands}" -- ${cur}))
                 return 0
                 ;;
@@ -124,15 +124,15 @@ _vagrant() {
     then
       action="${COMP_WORDS[COMP_CWORD-2]}"
       case "$action" in
-          "up")
+          up)
               if [ "$prev" == "--no-provision" ]; then
                   COMPREPLY=($(compgen -W "${vm_list}" -- ${cur}))
                   return 0
               fi
               ;;
-          "box")
+          box)
               case "$prev" in
-                  "remove"|"repackage")
+                  remove|repackage)
                       local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
                       COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
                       return 0
@@ -140,7 +140,7 @@ _vagrant() {
                   *)
               esac
               ;;
-          "snapshot")
+          snapshot)
               if [ "$prev" == "go" ]; then
                   local snapshot_list=$(vagrant snapshot list | awk '/Name:/ { print $2 }')
                   COMPREPLY=($(compgen -W "${snapshot_list}" -- ${cur}))

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -75,9 +75,43 @@ _vagrant() {
 
         case "$prev" in
 
+            box)
+                box_commands='add help list remove repackage'
+                COMPREPLY=($(compgen -W "${box_commands}" -- ${cur}))
+                return 0
+                ;;
+
+            halt|provision|reload|resume|ssh|ssh-config|suspend)
+                vagrant_state_file=$(__vagrantinvestigate) || return 1
+                if [[ -f $vagrant_state_file ]]; then
+                    running_vm_list=$(grep 'active' $vagrant_state_file | sed -e 's/"active"://' | tr ',' '\n' | cut -d '"' -f 2 | tr '\n' ' ')
+                else
+                    running_vm_list=$(find $vagrant_state_file -type f -name "id" | awk -F"/" '{print $(NF-2)}')
+                fi
+                COMPREPLY=($(compgen -W "${running_vm_list}" -- ${cur}))
+                return 0
+                ;;
+
+            help)
+                COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
+                return 0
+                ;;
+
             init)
                 local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
                 COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
+                return 0
+                ;;
+
+            plugin)
+                plugin_commands='install license list uninstall update'
+                COMPREPLY=($(compgen -W "${plugin_commands}" -- ${cur}))
+                return 0
+                ;;
+
+            snapshot)
+                snapshot_commands='back delete go list take'
+                COMPREPLY=($(compgen -W "${snapshot_commands}" -- ${cur}))
                 return 0
                 ;;
 
@@ -91,40 +125,6 @@ _vagrant() {
                 return 0
                 ;;
 
-            ssh|provision|reload|halt|suspend|resume|ssh-config)
-                vagrant_state_file=$(__vagrantinvestigate) || return 1
-                if [[ -f $vagrant_state_file ]]; then
-                    running_vm_list=$(grep 'active' $vagrant_state_file | sed -e 's/"active"://' | tr ',' '\n' | cut -d '"' -f 2 | tr '\n' ' ')
-                else
-                    running_vm_list=$(find $vagrant_state_file -type f -name "id" | awk -F"/" '{print $(NF-2)}')
-                fi
-                COMPREPLY=($(compgen -W "${running_vm_list}" -- ${cur}))
-                return 0
-                ;;
-
-            box)
-                box_commands='add help list remove repackage'
-                COMPREPLY=($(compgen -W "${box_commands}" -- ${cur}))
-                return 0
-                ;;
-
-            plugin)
-                plugin_commands='install license list uninstall update'
-                COMPREPLY=($(compgen -W "${plugin_commands}" -- ${cur}))
-                return 0
-                ;;
-
-            help)
-                COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
-                return 0
-                ;;
-
-            snapshot)
-                snapshot_commands='back delete go list take'
-                COMPREPLY=($(compgen -W "${snapshot_commands}" -- ${cur}))
-                return 0
-                ;;
-
         esac
 
     elif (( COMP_CWORD == 3 )); then
@@ -132,13 +132,6 @@ _vagrant() {
         action="${COMP_WORDS[COMP_CWORD-2]}"
 
         case "$action" in
-
-            up)
-                if [ "$prev" == "--no-provision" ]; then
-                    COMPREPLY=($(compgen -W "${vm_list}" -- ${cur}))
-                    return 0
-                fi
-                ;;
 
             box)
                 case "$prev" in
@@ -154,6 +147,13 @@ _vagrant() {
                 if [ "$prev" == "go" ]; then
                     local snapshot_list=$(vagrant snapshot list | awk '/Name:/ { print $2 }')
                     COMPREPLY=($(compgen -W "${snapshot_list}" -- ${cur}))
+                    return 0
+                fi
+                ;;
+
+            up)
+                if [ "$prev" == "--no-provision" ]; then
+                    COMPREPLY=($(compgen -W "${vm_list}" -- ${cur}))
                     return 0
                 fi
                 ;;

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -24,123 +24,143 @@
 
 
 __pwdln() {
-   pwdmod="${PWD}/"
-   itr=0
-   until [[ -z "$pwdmod" ]];do
-      itr=$(($itr+1))
-      pwdmod="${pwdmod#*/}"
-   done
-   echo -n $(($itr-1))
+    pwdmod="${PWD}/"
+    itr=0
+
+    until [[ -z "$pwdmod" ]]; do
+        itr=$(($itr+1))
+        pwdmod="${pwdmod#*/}"
+    done
+
+    echo -n $(($itr-1))
 }
 
 __vagrantinvestigate() {
-   if [ -n "$VAGRANT_CWD" ];then
-     if [ -f "${VAGRANT_CWD}/.vagrant" -o -d "${VAGRANT_CWD}/.vagrant" ];then
+    if [ -n "$VAGRANT_CWD" ]; then
+        if [ -f "${VAGRANT_CWD}/.vagrant" -o -d "${VAGRANT_CWD}/.vagrant" ]; then
         echo "${VAGRANT_CWD}/.vagrant"
         return 0
-     fi
-   fi
-   if [ -f "${PWD}/.vagrant" -o -d "${PWD}/.vagrant" ];then
-      echo "${PWD}/.vagrant"
-      return 0
-   else
-      pwdmod2="${PWD}"
-      for (( i=2; i<=$(__pwdln); i++ ));do
-         pwdmod2="${pwdmod2%/*}"
-         if [ -f "${pwdmod2}/.vagrant" -o -d "${pwdmod2}/.vagrant" ];then
-            echo "${pwdmod2}/.vagrant"
-            return 0
-         fi
-      done
-   fi
-   return 1
+        fi
+    fi
+
+    if [ -f "${PWD}/.vagrant" -o -d "${PWD}/.vagrant" ]; then
+        echo "${PWD}/.vagrant"
+        return 0
+    else
+        pwdmod2="${PWD}"
+        for (( i=2; i<=$(__pwdln); i++ )); do
+            pwdmod2="${pwdmod2%/*}"
+            if [ -f "${pwdmod2}/.vagrant" -o -d "${pwdmod2}/.vagrant" ]; then
+                echo "${pwdmod2}/.vagrant"
+                return 0
+            fi
+        done
+    fi
+
+    return 1
 }
 
 _vagrant() {
+
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     commands='snapshot box connect destroy docker-logs docker-run global-status halt help init list-commands login package plugin provision rdp reload resume rsync rsync-auto share ssh ssh-config status suspend up version'
 
-    if (( COMP_CWORD == 1 ))
-    then
-      COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
-      return 0
-    elif (( COMP_CWORD == 2 ))
-    then
+    if (( COMP_CWORD == 1 )); then
+
+        COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
+        return 0
+
+    elif (( COMP_CWORD == 2 )); then
+
         case "$prev" in
+
             init)
                 local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
                 COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
                 return 0
                 ;;
+
             up)
                 vagrant_state_file=$(__vagrantinvestigate) || return 1
-                if [[ -d $vagrant_state_file ]]
-                then
+                if [[ -d $vagrant_state_file ]]; then
                     vm_list=$(find $vagrant_state_file/machines -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
                 fi
                 local up_commands='--no-provision'
                 COMPREPLY=($(compgen -W "${up_commands} ${vm_list}" -- ${cur}))
                 return 0
                 ;;
+
             ssh|provision|reload|halt|suspend|resume|ssh-config)
                 vagrant_state_file=$(__vagrantinvestigate) || return 1
-                if [[ -f $vagrant_state_file ]]
-                then
-                      running_vm_list=$(grep 'active' $vagrant_state_file | sed -e 's/"active"://' | tr ',' '\n' | cut -d '"' -f 2 | tr '\n' ' ')
+                if [[ -f $vagrant_state_file ]]; then
+                    running_vm_list=$(grep 'active' $vagrant_state_file | sed -e 's/"active"://' | tr ',' '\n' | cut -d '"' -f 2 | tr '\n' ' ')
                 else
-                      running_vm_list=$(find $vagrant_state_file -type f -name "id" | awk -F"/" '{print $(NF-2)}')
+                    running_vm_list=$(find $vagrant_state_file -type f -name "id" | awk -F"/" '{print $(NF-2)}')
                 fi
                 COMPREPLY=($(compgen -W "${running_vm_list}" -- ${cur}))
                 return 0
                 ;;
+
             box)
                 box_commands='add help list remove repackage'
                 COMPREPLY=($(compgen -W "${box_commands}" -- ${cur}))
                 return 0
                 ;;
+
             plugin)
                 plugin_commands='install license list uninstall update'
                 COMPREPLY=($(compgen -W "${plugin_commands}" -- ${cur}))
                 return 0
                 ;;
+
             help)
                 COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
                 return 0
                 ;;
+
             snapshot)
                 snapshot_commands='back delete go list take'
                 COMPREPLY=($(compgen -W "${snapshot_commands}" -- ${cur}))
                 return 0
                 ;;
+
         esac
-    elif (( COMP_CWORD == 3 ))
-    then
-      action="${COMP_WORDS[COMP_CWORD-2]}"
-      case "$action" in
-          up)
-              if [ "$prev" == "--no-provision" ]; then
-                  COMPREPLY=($(compgen -W "${vm_list}" -- ${cur}))
-                  return 0
-              fi
-              ;;
-          box)
-              case "$prev" in
-                  remove|repackage)
-                      local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
-                      COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
-                      return 0
-                      ;;
-              esac
-              ;;
-          snapshot)
-              if [ "$prev" == "go" ]; then
-                  local snapshot_list=$(vagrant snapshot list | awk '/Name:/ { print $2 }')
-                  COMPREPLY=($(compgen -W "${snapshot_list}" -- ${cur}))
-                  return 0
-              fi
-              ;;
-      esac
+
+    elif (( COMP_CWORD == 3 )); then
+
+        action="${COMP_WORDS[COMP_CWORD-2]}"
+
+        case "$action" in
+
+            up)
+                if [ "$prev" == "--no-provision" ]; then
+                    COMPREPLY=($(compgen -W "${vm_list}" -- ${cur}))
+                    return 0
+                fi
+                ;;
+
+            box)
+                case "$prev" in
+                    remove|repackage)
+                        local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
+                        COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
+                        return 0
+                        ;;
+                esac
+                ;;
+
+            snapshot)
+                if [ "$prev" == "go" ]; then
+                    local snapshot_list=$(vagrant snapshot list | awk '/Name:/ { print $2 }')
+                    COMPREPLY=($(compgen -W "${snapshot_list}" -- ${cur}))
+                    return 0
+                fi
+                ;;
+
+        esac
+
     fi
 }
+
 complete -F _vagrant vagrant

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -27,141 +27,541 @@
 # ensure vagrant is on the PATH
 hash vagrant &>/dev/null && {
 
-__vagrantinvestigate() {
-    local path
+__vagrant_complete(){
+    local command_options=''
 
-    for path in "$VAGRANT_CWD" "$PWD"; do
-        if [[ -n $path ]]; then
-            until [[ $path = / ]]; do
-                if [[ -f $path/.vagrant || -d $path/.vagrant ]]; then
-                    echo "$path/.vagrant"
-                    return 0
-                fi
-                path=$(dirname "$path")
-            done
+    command_options=$(__vagrant_list_options "$@")
+    [[ -z $command_options ]] && return 1
+
+    readarray -t COMPREPLY < <(compgen -W "$command_options" -- "$cur")
+
+    return 0
+}
+
+__vagrant_complete_providers(){
+    local providers=()
+
+    providers=(docker hyperv libvirt lxc virtualbox vmware_fusion)
+
+    readarray -t COMPREPLY < <(compgen -W "${providers[*]}" -- "$cur")
+
+    return 0
+}
+
+__vagrant_complete_provisioners(){
+    local provisioners=()
+
+    provisioners=(ansible cfengine chef_apply chef_client chef_solo \
+                  chef_zero docker file puppet puppet_server salt shell)
+
+    readarray -t COMPREPLY < <(compgen -W "${provisioners[*]}" -- "$cur")
+
+    return 0
+}
+
+__vagrant_get_boxes(){
+
+    local vagrant_boxes=''
+
+    vagrant_boxes=$(find "$HOME/.vagrant.d/boxes" -maxdepth 1 -mindepth 1 -type d -printf '%P\n' 2>/dev/null | sed 's/-VAGRANTSLASH-/\//')
+
+    [[ -z $vagrant_boxes ]] && return 1
+
+    echo "$vagrant_boxes"
+}
+
+__vagrant_get_commands(){
+
+    local vagrant_commands='' vagrant_output=''
+
+    # local must be declared beforehand in order to return an accurate exit status here
+    vagrant_output=$(vagrant list-commands 2>/dev/null) || return 1
+
+    # `NF != 0` is there solely to insure against any errata appended to list-commands output at a later date
+    vagrant_commands=$(awk '/^$/ {while (getline && NF != 0) print $1}' <<<"$vagrant_output" | sort)
+
+    [[ -z $vagrant_commands ]] && return 1
+
+    echo "$vagrant_commands"
+}
+
+__vagrant_get_environments(){
+
+    local vagrant_environments='' vagrant_output=''
+
+    # local must be declared beforehand in order to return an accurate exit status here
+    vagrant_output=$(vagrant global-status 2>/dev/null) || return 1
+
+    vagrant_environments=$(awk '/^-+$/ {while (getline && NF != 0) print $1}' <<<"$vagrant_output")
+
+    [[ -z $vagrant_environments ]] && return 1
+
+    echo "$vagrant_environments"
+}
+
+__vagrant_get_nonrunning_vms(){
+
+    local vagrant_output='' vagrant_vms=''
+
+    # local must be declared beforehand in order to return an accurate exit status here
+    vagrant_output=$(vagrant status 2>/dev/null) || return 1
+
+    vagrant_vms=$(awk '/^$/ {while (getline && NF != 0) if ($2 != "running") print $1}' <<<"$vagrant_output")
+
+    [[ -z $vagrant_vms ]] && return 1
+
+    echo "$vagrant_vms"
+}
+
+# ignore current word and actions
+__vagrant_get_options(){
+
+    local arg
+
+    for arg in "${COMP_WORDS[@]:0:$((${#COMP_WORDS[@]}-1))}"; do
+        [[ $arg = -* ]] && echo "$arg"
+    done
+
+    return 0
+}
+
+__vagrant_get_running_vms(){
+
+    local vagrant_output='' vagrant_vms=''
+
+    # local must be declared beforehand in order to return an accurate exit status here
+    vagrant_output=$(vagrant status 2>/dev/null) || return 1
+
+    vagrant_vms=$(awk '/^$/ {while (getline && NF != 0) if ($2 != "poweroff") print $1}' <<<"$vagrant_output")
+
+    [[ -z $vagrant_vms ]] && return 1
+
+    echo "$vagrant_vms"
+}
+
+__vagrant_get_snapshots(){
+
+    local vagrant_output='' vagrant_snapshots=''
+
+    # local must be declared beforehand in order to return an accurate exit status here
+    vagrant_output=$(vagrant snapshot list 2>/dev/null) || return 1
+
+    vagrant_snapshots=$(awk '$1 ~ /Name:/ {print $2}' <<<"$vagrant_output")
+
+    [[ -z $vagrant_snapshots ]] && return 1
+
+    echo "$vagrant_snapshots"
+}
+
+__vagrant_get_subcommands(){
+
+    local vagrant_output='' vagrant_subcommands=''
+
+    # local must be declared beforehand in order to return an accurate exit status here
+    vagrant_output=$(vagrant help "$1" 2>/dev/null) || return 1
+
+    vagrant_subcommands=$(awk '/^Available subcommands:$/ {while (getline && NF == 1) print $1}' <<<"$vagrant_output")
+    # vagrant_subcommands=$(awk '/^     [a-z]+$/ {print $1}' <<<"$vagrant_output")
+
+    [[ -z $vagrant_subcommands ]] && return 1
+
+    echo "$vagrant_subcommands"
+}
+
+__vagrant_get_vms(){
+
+    local vagrant_output='' vagrant_vms=''
+
+    # local must be declared beforehand in order to return an accurate exit status here
+    vagrant_output=$(vagrant status 2>/dev/null) || return 1
+
+    vagrant_vms=$(awk '/^$/ {while (getline && NF != 0) print $1}' <<<"$vagrant_output")
+
+    [[ -z $vagrant_vms ]] && return 1
+
+    echo "$vagrant_vms"
+}
+
+# ignore current word and options
+__vagrant_get_words(){
+
+    eval set -- "${COMP_WORDS[@]:0:$((${#COMP_WORDS[@]}-1))}"
+
+    while (( $# > 0 )); do
+        # some options consume an argument
+        if [[ $1 =~ ^(--base|--box|--box-version|-c|--cacert|--capath|--cert|--checksum|--checksum-type|--command|--entry-point|--host|--include|--name|--output|--provider|--plugin-source|--plugin-version|--provision-with|-t|--token|--vagrantfile)$ ]]; then
+            shift
+        # some share plugin options consume an argument
+        elif [[ $1 =~ ^(--domain|--http|--https|--name|--ssh-port|--static-ip)$ ]]; then
+            shift
+        elif [[ $1 != -* ]]; then
+            echo "$1"
         fi
+        shift
+    done
+}
+
+# accept options as arguments and output unused options
+__vagrant_list_options(){
+
+    local opt opts=()
+
+    for opt in "$@"; do
+        __vagrant_test_option "$opt" || opts+=("$opt")
+    done
+
+    echo "${opts[@]}"
+}
+
+# accept option as argument and return successfully if option has already been used
+__vagrant_test_option(){
+
+    local option
+
+    for option in "${options[@]}"; do
+        [[ $option = "$1" ]] && return 0
     done
 
     return 1
 }
 
-__vagrantrunningvms(){
-    local vagrant_state_file
-
-    vagrant_state_file=$(__vagrantinvestigate)
-
-    if [[ -f $vagrant_state_file ]]; then
-        grep active "$vagrant_state_file" | sed -e 's/"active"://' | tr ',' '\n' | cut -d '"' -f 2 | tr '\n' ' '
-    elif [[ -d $vagrant_state_file ]]; then
-        find "$vagrant_state_file" -type f -name id 2>/dev/null | awk -F/ '{print $(NF-2)}'
-    fi
-}
-
-__vagrantvms() {
-    local vagrant_state_file
-
-    vagrant_state_file=$(__vagrantinvestigate)
-
-    if [[ -d $vagrant_state_file ]]; then
-        find "$vagrant_state_file/machines" -maxdepth 1 -mindepth 1 -type d -printf '%P\n' 2>/dev/null
-    fi
-}
-
 __vagrant(){
 
-    local box_commands box_list cur environments plugin_commands prev running_vm_list snapshot_commands snapshot_list up_commands vm_list
+    local action='' cur='' options=() subaction='' words=()
 
     cur=${COMP_WORDS[COMP_CWORD]}
     prev=${COMP_WORDS[COMP_CWORD-1]}
-    __vagrantcommands=$(vagrant list-commands 2>/dev/null | awk '/^$/ { while (getline) print $1 }' | sort)
 
-    [[ -z $__vagrantcommands ]] && return 1
+    readarray -t options < <(__vagrant_get_options)
+    readarray -t words < <(__vagrant_get_words)
 
-    if (( COMP_CWORD == 1 )); then
+    action=${words[1]}
+    subaction=${words[2]}
 
-        COMPREPLY=($(compgen -W "$__vagrantcommands" -- "$cur"))
+    # NOTE: the following vars are cached in the global environment for speedy completion in the future
+    #       __vagrant_commands
+    #       __vagrant_box_commands
+    #       __vagrant_plugin_commands
+    #       __vagrant_snapshot_commands
+
+    if (( ${#words[@]} == 1 )); then
+
+        # DEFAULTS: box connect destroy docker-logs docker-run global-status
+        #           halt help init list-commands login package plugin provision
+        #           push rdp reload resume rsync rsync-auto share ssh ssh-config
+        #           status suspend up version
+
+        # get vagrant commands only if they are not already cached
+        [[ -z $__vagrant_commands ]] && {
+            __vagrant_commands=$(__vagrant_get_commands) || return 1
+        }
+
+        readarray -t COMPREPLY < <(compgen -W "$__vagrant_commands" -- "$cur")
+
         return 0
 
-    elif (( COMP_CWORD == 2 )); then
+    elif (( ${#words[@]} == 2 )); then
 
-        case "$prev" in
+        case "$action" in
 
             box)
-                box_commands='add help list remove repackage'
-                COMPREPLY=($(compgen -W "$box_commands" -- "$cur"))
+                # DEFAULTS: add help list outdated remove repackage update
+
+                # get box commands only if they are not already cached
+                [[ -z $__vagrant_box_commands ]] && {
+                    __vagrant_box_commands=$(__vagrant_get_subcommands box) || return 1
+                }
+
+                readarray -t COMPREPLY < <(compgen -W "$__vagrant_box_commands" -- "$cur")
+
                 return 0
+                ;;
+
+            connect)
+                [[ $prev = --static-ip ]] && return 0
+
+                __vagrant_complete --disable-static-ip --ssh --static-ip
+
+                return $?
                 ;;
 
             destroy)
-                environments=$(vagrant global-status 2>/dev/null | awk '/^-{80}$/ { getline; while (NF != 0) { print$1; getline } }')
-                COMPREPLY=($(compgen -W "$environments" -- "$cur"))
+                local destroy_options='' environments=''
+
+                destroy_options=$(__vagrant_list_options -f --force)
+                environments=$(__vagrant_get_environments) || return 1
+
+                readarray -t COMPREPLY < <(compgen -W "$destroy_options $environments" -- "$cur")
+
                 return 0
                 ;;
 
-            halt|provision|reload|resume|ssh|ssh-config|suspend)
-                running_vm_list=$(__vagrantrunningvms)
-                COMPREPLY=($(compgen -W "$running_vm_list" -- "$cur"))
+            docker-logs)
+                __vagrant_complete --follow --no-follow --no-prefix --prefix
+
+                return $?
+                ;;
+
+            docker-run)
+                __vagrant_complete --detach --no-detach --no-rm --no-tty -r --rm -t --tty
+
+                return $?
+                ;;
+
+            global-status)
+                __vagrant_complete --prune
+
+                return $?
+                ;;
+
+            halt|provision|resume|rsync|rsync-auto|ssh|ssh-config|suspend)
+                local command_options='' running_vm_list=''
+
+                case "$action" in
+
+                    halt)
+                        command_options=$(__vagrant_list_options -f --force)
+                        ;;
+
+                    provision)
+                        if [[ $prev = --provision-with ]]; then
+                            __vagrant_complete_provisioners
+                            return $?
+                        fi
+
+                        command_options=$(__vagrant_list_options --provision-with)
+                        ;;
+
+                    rsync-auto)
+                        command_options=$(__vagrant_list_options --no-poll --poll)
+                        ;;
+
+                    ssh)
+                        [[ $prev =~ ^(-c|--command)$ ]] && return 0
+
+                        command_options=$(__vagrant_list_options -c --command -p --plain)
+                        ;;
+
+                    ssh-config)
+                        [[ $prev = --host ]] && return 0
+
+                        command_options=$(__vagrant_list_options --host)
+                        ;;
+
+                esac
+
+                running_vm_list=$(__vagrant_get_running_vms) || return 1
+
+                readarray -t COMPREPLY < <(compgen -W "$command_options $running_vm_list" -- "$cur")
+
                 return 0
                 ;;
 
             help)
-                COMPREPLY=($(compgen -W "$__vagrantcommands" -- "$cur"))
+                # get vagrant commands only if they are not already cached
+                [[ -z $__vagrant_commands ]] && {
+                    __vagrant_commands=$(__vagrant_get_commands) || return 1
+                }
+
+                readarray -t COMPREPLY < <(compgen -W "$__vagrant_commands" -- "$cur")
+
                 return 0
                 ;;
 
             init)
-                box_list=$(__vagrantboxes)
-                COMPREPLY=($(compgen -W "$box_list" -- "$cur"))
+                [[ $prev = --output ]] && return 0
+
+                local box_list='' init_options=''
+
+                init_options=$(__vagrant_list_options -f --force -m --minimal --output)
+                box_list=$(__vagrant_get_boxes) || return 1
+
+                readarray -t COMPREPLY < <(compgen -W "$init_options $box_list" -- "$cur")
+
                 return 0
                 ;;
 
+            login)
+                [[ $prev =~ ^(-t|--token)$ ]] && return 0
+
+                __vagrant_complete -c --check -k --logout -t --token
+
+                return $?
+                ;;
+
+            package)
+                [[ $prev =~ ^(--base|--output|--include|--vagrantfile)$ ]] && return 0
+
+                __vagrant_complete --base --include --output --vagrantfile
+
+                return $?
+                ;;
+
             plugin)
-                plugin_commands='install license list uninstall update'
-                COMPREPLY=($(compgen -W "$plugin_commands" -- "$cur"))
+                # DEFAULTS: install license list uninstall update
+
+                # get plugin commands only if they are not already cached
+                [[ -z $__vagrant_plugin_commands ]] && {
+                    __vagrant_plugin_commands=$(__vagrant_get_subcommands plugin) || return 1
+                }
+
+                readarray -t COMPREPLY < <(compgen -W "$__vagrant_plugin_commands" -- "$cur")
+
+                return 0
+                ;;
+
+            reload)
+                if [[ $prev = --provision-with ]]; then
+                    __vagrant_complete_provisioners
+                    return $?
+                fi
+
+                local command_options='' vm_list=''
+
+                command_options=$(__vagrant_list_options --no-provision --provision --provision-with)
+                vm_list=$(__vagrant_get_vms) || return 1
+
+                readarray -t COMPREPLY < <(compgen -W "$up_options $vm_list" -- "$cur")
+
+                return 0
+                ;;
+
+            share)
+                [[ $prev =~ ^(--domain|--http|--https|--name|--ssh-port)$ ]] && return 0
+
+                __vagrant_complete --disable-http --domain --http --https --name --ssh --ssh-no-password --ssh-once --ssh-port
+
                 return 0
                 ;;
 
             snapshot)
-                snapshot_commands='back delete go list take'
-                COMPREPLY=($(compgen -W "$snapshot_commands" -- "$cur"))
+                # DEFAULTS: back delete go list take
+
+                # get snapshot commands only if they are not already cached
+                [[ -z $__vagrant_snapshot_commands ]] && {
+                    __vagrant_snapshot_commands=$(__vagrant_get_subcommands snapshot) || return 1
+                }
+
+                readarray -t COMPREPLY < <(compgen -W "$__vagrant_snapshot_commands" -- "$cur")
+
                 return 0
                 ;;
 
             up)
-                up_commands='--no-provision'
-                vm_list=$(__vagrantvms)
-                COMPREPLY=($(compgen -W "$up_commands $vm_list" -- "$cur"))
+                if [[ $prev = --provider ]]; then
+                    __vagrant_complete_providers
+                    return $?
+                elif [[ $prev = --provision-with ]]; then
+                    __vagrant_complete_provisioners
+                    return $?
+                fi
+
+                local up_options='' nonrunning_vm_list=''
+
+                up_options=$(__vagrant_list_options --destroy-on-error --no-destroy-on-error --no-parallel --no-provision --parallel --provider --provision --provision-with)
+                nonrunning_vm_list=$(__vagrant_get_nonrunning_vms) || return 1
+
+                readarray -t COMPREPLY < <(compgen -W "$up_options $nonrunning_vm_list" -- "$cur")
+
                 return 0
                 ;;
 
         esac
 
-    elif (( COMP_CWORD == 3 )); then
-
-        action=${COMP_WORDS[COMP_CWORD-2]}
+    elif (( ${#words[@]} == 3 )); then
 
         case "$action" in
 
             box)
-                if [[ $prev =~ ^(remove|repackage)$ ]]; then
-                    box_list=$(__vagrantboxes)
-                    COMPREPLY=($(compgen -W "$box_list" -- "$cur"))
+                case "$subaction" in
+
+                    add)
+                        if [[ $prev =~ ^(--box-version|--cacert|--capath|--cert|--checksum|--checksum-type|--name|--provider)$ ]]; then
+                            return 0
+                        elif [[ $prev = --provider ]]; then
+                            __vagrant_complete_providers
+                            return $?
+                        fi
+
+                        __vagrant_complete --box-version -c --cacert --capath \
+                                           --cert --checksum --checksum-type \
+                                           --clean -f --force --insecure \
+                                           --location-trusted --name --provider
+                        return $?
+                        ;;
+
+                    list)
+                        __vagrant_complete -i --box-info
+                        return $?
+                        ;;
+
+                    outdated)
+                        __vagrant_complete --global
+                        return $?
+                        ;;
+
+                    remove)
+                        [[ $prev =~ ^(--box-version|--provider)$ ]] && return 0
+
+                        local remove_options=''
+
+                        remove_options=$(__vagrant_list_options -f --force -m --minimal --output)
+                        ;;
+
+                    update)
+                        if [[ $prev =~ ^(--box|--provider)$ ]]; then
+                            return 0
+                        elif [[ $prev = --provider ]]; then
+                            __vagrant_complete_providers
+                            return $?
+                        fi
+
+                        __vagrant_complete --box --provider
+                        return $?
+                        ;;
+
+                esac
+
+                if [[ $subaction =~ ^(remove|repackage)$ ]]; then
+                    local box_list=''
+
+                    box_list=$(__vagrant_get_boxes) || return 1
+
+                    readarray -t COMPREPLY < <(compgen -W "$remove_options $box_list" -- "$cur")
+
                     return 0
                 fi
+                ;;
+
+            plugin)
+                case "$subaction" in
+                    install)
+                        [[ $prev =~ ^(--entry-point|--plugin-source|--plugin-version)$ ]] && return 0
+
+                        __vagrant_complete --entry-point --plugin-prerelease \
+                                           --plugin-source --plugin-version \
+                                           --verbose
+                        return $?
+                        ;;
+                esac
                 ;;
 
             snapshot)
-                if [[ $prev = go ]]; then
-                    snapshot_list=$(vagrant snapshot list | awk '/Name:/ { print $2 }')
-                    COMPREPLY=($(compgen -W "$snapshot_list" -- "$cur"))
-                    return 0
-                fi
-                ;;
+                case "$subaction" in
+                    go)
+                        local go_options=''
 
-            up)
-                if [[ $prev = --no-provision ]]; then
-                    vm_list=$(__vagrantvms)
-                    COMPREPLY=($(compgen -W "$vm_list" -- "$cur"))
+                        go_options=$(__vagrant_list_options -r --reload)
+                        ;;
+                esac
+
+                if [[ $subaction =~ ^(delete|go)$ ]]; then
+                    local snapshot_list=''
+
+                    snapshot_list=$(__vagrant_get_snapshots) || return 1
+
+                    readarray -t COMPREPLY < <(compgen -W "$go_options $snapshot_list" -- "$cur")
+
                     return 0
                 fi
                 ;;

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -3,6 +3,7 @@
 # (The MIT License)
 #
 # Copyright (c) 2014 Kura
+# Copyright (c) 2015 Six <brbsix@gmail.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the 'Software'), to deal

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -115,8 +115,6 @@ _vagrant() {
                 COMPREPLY=($(compgen -W "${snapshot_commands}" -- ${cur}))
                 return 0
                 ;;
-            *)
-            ;;
         esac
     fi
 
@@ -137,7 +135,6 @@ _vagrant() {
                       COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
                       return 0
                       ;;
-                  *)
               esac
               ;;
           snapshot)

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -73,7 +73,7 @@ _vagrant() {
 
     cur=${COMP_WORDS[COMP_CWORD]}
     prev=${COMP_WORDS[COMP_CWORD-1]}
-    __vagrantcommands=$(vagrant list-commands 2>/dev/null | tail -n+4 | awk '{print $1}' | sort)
+    __vagrantcommands=$(vagrant list-commands 2>/dev/null | awk '/^$/ { while (getline) print $1 }' | sort)
 
     [[ -z $__vagrantcommands ]] && return 1
 

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -28,6 +28,8 @@ __vagrantboxes() {
 }
 
 __vagrantinvestigate() {
+    local path
+
     for path in "$VAGRANT_CWD" "$PWD"; do
         if [[ -n $path ]]; then
             until [[ $path = / ]]; do
@@ -39,6 +41,7 @@ __vagrantinvestigate() {
             done
         fi
     done
+
     return 1
 }
 
@@ -65,6 +68,8 @@ __vagrantvms() {
 }
 
 _vagrant() {
+
+    local box_commands box_list cur environments plugin_commands prev running_vm_list snapshot_commands snapshot_list up_commands vm_list
 
     cur=${COMP_WORDS[COMP_CWORD]}
     prev=${COMP_WORDS[COMP_CWORD-1]}
@@ -99,7 +104,7 @@ _vagrant() {
                 ;;
 
             init)
-                local box_list=$(__vagrantboxes)
+                box_list=$(__vagrantboxes)
                 COMPREPLY=($(compgen -W "$box_list" -- "$cur"))
                 return 0
                 ;;
@@ -133,7 +138,7 @@ _vagrant() {
 
             box)
                 if [[ $prev =~ ^(remove|repackage)$ ]]; then
-                    local box_list=$(__vagrantboxes)
+                    box_list=$(__vagrantboxes)
                     COMPREPLY=($(compgen -W "$box_list" -- "$cur"))
                     return 0
                 fi
@@ -141,7 +146,7 @@ _vagrant() {
 
             snapshot)
                 if [[ $prev = go ]]; then
-                    local snapshot_list=$(vagrant snapshot list | awk '/Name:/ { print $2 }')
+                    snapshot_list=$(vagrant snapshot list | awk '/Name:/ { print $2 }')
                     COMPREPLY=($(compgen -W "$snapshot_list" -- "$cur"))
                     return 0
                 fi

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -23,6 +23,10 @@
 # SOFTWARE.
 
 
+__vagrantboxes() {
+    find "$HOME/.vagrant.d/boxes" -maxdepth 1 -mindepth 1 -type d -printf '%P\n' | sed 's/-VAGRANTSLASH-/\//' 2>/dev/null
+}
+
 __pwdln() {
     pwdmod=$PWD/
     itr=0
@@ -86,7 +90,7 @@ _vagrant() {
                 if [[ -f $vagrant_state_file ]]; then
                     running_vm_list=$(grep active "$vagrant_state_file" | sed -e 's/"active"://' | tr ',' '\n' | cut -d '"' -f 2 | tr '\n' ' ')
                 else
-                    running_vm_list=$(find "$vagrant_state_file" -type f -name id | awk -F/ '{print $(NF-2)}')
+                    running_vm_list=$(find "$vagrant_state_file" -type f -name id 2>/dev/null | awk -F/ '{print $(NF-2)}')
                 fi
                 COMPREPLY=($(compgen -W "$running_vm_list" -- "$cur"))
                 return 0
@@ -98,7 +102,7 @@ _vagrant() {
                 ;;
 
             init)
-                local box_list=$(find "$HOME/.vagrant.d/boxes" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
+                local box_list=$(__vagrantboxes)
                 COMPREPLY=($(compgen -W "$box_list" -- "$cur"))
                 return 0
                 ;;
@@ -118,7 +122,7 @@ _vagrant() {
             up)
                 vagrant_state_file=$(__vagrantinvestigate) || return 1
                 if [[ -d $vagrant_state_file ]]; then
-                    vm_list=$(find "$vagrant_state_file/machines" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+                    vm_list=$(find "$vagrant_state_file/machines" -maxdepth 1 -mindepth 1 -type d -printf '%P\n' 2>/dev/null)
                 fi
                 local up_commands='--no-provision'
                 COMPREPLY=($(compgen -W "$up_commands $vm_list" -- "$cur"))
@@ -136,7 +140,7 @@ _vagrant() {
             box)
                 case "$prev" in
                     remove|repackage)
-                        local box_list=$(find "$HOME/.vagrant.d/boxes" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
+                        local box_list=$(__vagrantboxes)
                         COMPREPLY=($(compgen -W "$box_list" -- "$cur"))
                         return 0
                         ;;

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -46,11 +46,13 @@ _vagrant() {
 
     cur=${COMP_WORDS[COMP_CWORD]}
     prev=${COMP_WORDS[COMP_CWORD-1]}
-    commands=$(vagrant list-commands 2>/dev/null | tail -n+4 | awk '{print $1}' | sort)
+    __vagrantcommands=$(vagrant list-commands 2>/dev/null | tail -n+4 | awk '{print $1}' | sort)
+
+    [[ -z $__vagrantcommands ]] && return 1
 
     if (( COMP_CWORD == 1 )); then
 
-        COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+        COMPREPLY=($(compgen -W "$__vagrantcommands" -- "$cur"))
         return 0
 
     elif (( COMP_CWORD == 2 )); then
@@ -75,7 +77,7 @@ _vagrant() {
                 ;;
 
             help)
-                COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+                COMPREPLY=($(compgen -W "$__vagrantcommands" -- "$cur"))
                 return 0
                 ;;
 

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -27,40 +27,18 @@ __vagrantboxes() {
     find "$HOME/.vagrant.d/boxes" -maxdepth 1 -mindepth 1 -type d -printf '%P\n' | sed 's/-VAGRANTSLASH-/\//' 2>/dev/null
 }
 
-__pwdln() {
-    pwdmod=$PWD/
-    itr=0
-
-    until [[ -z $pwdmod ]]; do
-        itr=$(( itr + 1 ))
-        pwdmod=${pwdmod#*/}
-    done
-
-    echo -n $(( itr - 1 ))
-}
-
 __vagrantinvestigate() {
-    if [[ -n $VAGRANT_CWD ]]; then
-        if [[ -f $VAGRANT_CWD/.vagrant || -d $VAGRANT_CWD/.vagrant ]]; then
-        echo "$VAGRANT_CWD/.vagrant"
-        return 0
+    for path in "$VAGRANT_CWD" "$PWD"; do
+        if [[ -n $path ]]; then
+            until [[ $path = / ]]; do
+                if [[ -f $path/.vagrant || -d $path/.vagrant ]]; then
+                    echo "$path/.vagrant"
+                    return 0
+                fi
+                path=$(dirname "$path")
+            done
         fi
-    fi
-
-    if [[ -f $PWD/.vagrant || -d $PWD/.vagrant ]]; then
-        echo "$PWD/.vagrant"
-        return 0
-    else
-        pwdmod2=$PWD
-        for (( i=2; i<=$(__pwdln); i++ )); do
-            pwdmod2=${pwdmod2%/*}
-            if [[ -f $pwdmod2/.vagrant || -d $pwdmod2/.vagrant ]]; then
-                echo "$pwdmod2/.vagrant"
-                return 0
-            fi
-        done
-    fi
-
+    done
     return 1
 }
 

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -24,9 +24,8 @@
 # SOFTWARE.
 
 
-__vagrantboxes() {
-    find "$HOME/.vagrant.d/boxes" -maxdepth 1 -mindepth 1 -type d -printf '%P\n' | sed 's/-VAGRANTSLASH-/\//' 2>/dev/null
-}
+# ensure vagrant is on the PATH
+hash vagrant &>/dev/null && {
 
 __vagrantinvestigate() {
     local path
@@ -173,3 +172,5 @@ _vagrant() {
 }
 
 complete -F _vagrant vagrant
+
+}

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -67,7 +67,7 @@ __vagrantvms() {
     fi
 }
 
-_vagrant() {
+__vagrant(){
 
     local box_commands box_list cur environments plugin_commands prev running_vm_list snapshot_commands snapshot_list up_commands vm_list
 
@@ -171,6 +171,6 @@ _vagrant() {
     fi
 }
 
-complete -F _vagrant vagrant
+complete -F __vagrant vagrant
 
 }

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -61,13 +61,11 @@ _vagrant() {
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     commands='snapshot box connect destroy docker-logs docker-run global-status halt help init list-commands login package plugin provision rdp reload resume rsync rsync-auto share ssh ssh-config status suspend up version'
 
-    if [ $COMP_CWORD == 1 ]
+    if (( COMP_CWORD == 1 ))
     then
       COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
       return 0
-    fi
-
-    if [ $COMP_CWORD == 2 ]
+    elif (( COMP_CWORD == 2 ))
     then
         case "$prev" in
             init)
@@ -116,9 +114,7 @@ _vagrant() {
                 return 0
                 ;;
         esac
-    fi
-
-    if [ $COMP_CWORD == 3 ]
+    elif (( COMP_CWORD == 3 ))
     then
       action="${COMP_WORDS[COMP_CWORD-2]}"
       case "$action" in

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -92,6 +92,12 @@ _vagrant() {
                 return 0
                 ;;
 
+            destroy)
+                environments=$(vagrant global-status 2>/dev/null | awk '/^-{80}$/ {getline; while (NF != 0) {ids[$1]++; getline}} END {if (length(ids)) for (id in ids) print id; else exit(1)}') || return 1
+                COMPREPLY=($(compgen -W "$environments" -- "$cur"))
+                return 0
+                ;;
+
             halt|provision|reload|resume|ssh|ssh-config|suspend)
                 running_vm_list=$(__vagrantrunningvms)
                 COMPREPLY=($(compgen -W "$running_vm_list" -- "$cur"))

--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -42,6 +42,28 @@ __vagrantinvestigate() {
     return 1
 }
 
+__vagrantrunningvms(){
+    local vagrant_state_file
+
+    vagrant_state_file=$(__vagrantinvestigate)
+
+    if [[ -f $vagrant_state_file ]]; then
+        grep active "$vagrant_state_file" | sed -e 's/"active"://' | tr ',' '\n' | cut -d '"' -f 2 | tr '\n' ' '
+    elif [[ -d $vagrant_state_file ]]; then
+        find "$vagrant_state_file" -type f -name id 2>/dev/null | awk -F/ '{print $(NF-2)}'
+    fi
+}
+
+__vagrantvms() {
+    local vagrant_state_file
+
+    vagrant_state_file=$(__vagrantinvestigate)
+
+    if [[ -d $vagrant_state_file ]]; then
+        find "$vagrant_state_file/machines" -maxdepth 1 -mindepth 1 -type d -printf '%P\n' 2>/dev/null
+    fi
+}
+
 _vagrant() {
 
     cur=${COMP_WORDS[COMP_CWORD]}
@@ -66,12 +88,7 @@ _vagrant() {
                 ;;
 
             halt|provision|reload|resume|ssh|ssh-config|suspend)
-                vagrant_state_file=$(__vagrantinvestigate) || return 1
-                if [[ -f $vagrant_state_file ]]; then
-                    running_vm_list=$(grep active "$vagrant_state_file" | sed -e 's/"active"://' | tr ',' '\n' | cut -d '"' -f 2 | tr '\n' ' ')
-                else
-                    running_vm_list=$(find "$vagrant_state_file" -type f -name id 2>/dev/null | awk -F/ '{print $(NF-2)}')
-                fi
+                running_vm_list=$(__vagrantrunningvms)
                 COMPREPLY=($(compgen -W "$running_vm_list" -- "$cur"))
                 return 0
                 ;;
@@ -100,11 +117,8 @@ _vagrant() {
                 ;;
 
             up)
-                vagrant_state_file=$(__vagrantinvestigate) || return 1
-                if [[ -d $vagrant_state_file ]]; then
-                    vm_list=$(find "$vagrant_state_file/machines" -maxdepth 1 -mindepth 1 -type d -printf '%P\n' 2>/dev/null)
-                fi
-                local up_commands='--no-provision'
+                up_commands='--no-provision'
+                vm_list=$(__vagrantvms)
                 COMPREPLY=($(compgen -W "$up_commands $vm_list" -- "$cur"))
                 return 0
                 ;;
@@ -135,6 +149,7 @@ _vagrant() {
 
             up)
                 if [[ $prev = --no-provision ]]; then
+                    vm_list=$(__vagrantvms)
                     COMPREPLY=($(compgen -W "$vm_list" -- "$cur"))
                     return 0
                 fi


### PR DESCRIPTION
I've done a pretty significant cleanup of vagrant's bash completion. Here it is in the event it can be of any use to you. I haven't tested it too thoroughly but it should be a hefty improvement.

Some of the bigger fixes:
* cache an accurate list of available commands (this way plugin commands like `snapshot` will only be completed if they are actually available)
* add completion for `destroy` command
* fixed some wonky things (e.g. `up` subcommands would not complete unless *$vagrant_state_file* was already cached from an earlier completion)
* keep (mostly) everything tidy in it's local namespace
* use of appropriate quoting, indentation, and best/latest builtins (e.g. `((` `[[` `=~`)