### PR TITLE
This closes #34, use VAGRANT_HOME when it's possible

### DIFF
--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -71,7 +71,7 @@ _vagrant() {
     then
         case "$prev" in
             "init")
-                local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
+                local box_list=$(find ${VAGRANT_HOME:-$HOME/.vagrant.d}/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
                 COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
                 return 0
                 ;;
@@ -133,7 +133,7 @@ _vagrant() {
           "box")
               case "$prev" in
                   "remove"|"repackage")
-                      local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
+                      local box_list=$(find ${VAGRANT_HOME:-$HOME/.vagrant.d}/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;|sed -e 's/-VAGRANTSLASH-/\//')
                       COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
                       return 0
                       ;;


### PR DESCRIPTION
Boxes search will be made either on the default path or the path defined in the VAGRANT_HOME variable.
