### PR TITLE
Add "vagrant destroy" as completion-rule

### DIFF
--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -85,7 +85,7 @@ _vagrant() {
                 COMPREPLY=($(compgen -W "${up_commands} ${vm_list}" -- ${cur}))
                 return 0
                 ;;
-            "ssh"|"provision"|"reload"|"halt"|"suspend"|"resume"|"ssh-config")
+            "ssh"|"provision"|"reload"|"halt"|"suspend"|"resume"|"ssh-config"|"destroy")
                 vagrant_state_file=$(__vagrantinvestigate) || return 1
                 if [[ -f $vagrant_state_file ]]
                 then


### PR DESCRIPTION
Make "vagrant destroy"  follow the same completion-rule as other command that depends on running machines.