### PR TITLE
Add ‘prune’ subcommand (vagrant box prune)

### DIFF
--- a/etc/bash_completion.d/vagrant
+++ b/etc/bash_completion.d/vagrant
@@ -97,7 +97,7 @@ _vagrant() {
                 return 0
                 ;;
             "box")
-                box_commands="add help list remove repackage"
+                box_commands="add help list remove prune repackage"
                 COMPREPLY=($(compgen -W "${box_commands}" -- ${cur}))
                 return 0
                 ;;


### PR DESCRIPTION
Even hard to find in the official documentation, because missing from the menu.
But, there it is: https://www.vagrantup.com/docs/cli/box.html#box-prune

Please merge, thanks in advance